### PR TITLE
Allow passing extra param to execQuery (for direct URL access)

### DIFF
--- a/osm_rawdata/config.py
+++ b/osm_rawdata/config.py
@@ -185,8 +185,7 @@ class QueryConfig(object):
                     self.config["select"][table].append({tag: []})
 
     def parseJson(self, config: Union[str, BytesIO]):
-        """Parse the JSON format config file used by the raw-data-api
-        and export tool.
+        """Parse the JSON format config file used by the raw-data-api and export tool.
 
         Args:
             config (str, BytesIO): the file or BytesIO object to read.
@@ -194,6 +193,18 @@ class QueryConfig(object):
         Returns:
             config (dict): the config data
         """
+
+        # Helper function to convert geometry names
+        def convert_geometry(geom):
+            if geom == "point":
+                return "nodes"
+            elif geom == "line":
+                return "ways_line"
+            elif geom == "polygon":
+                return "ways_poly"
+            return geom
+
+        # Check the type of config and load data accordingly
         if isinstance(config, str):
             with open(config, "r") as config_file:
                 data = json.load(config_file)
@@ -203,51 +214,48 @@ class QueryConfig(object):
             log.error(f"Unsupported config format: {config}")
             raise ValueError(f"Invalid config {config}")
 
-        # Get the geometry
+        # Extract geometry
         self.geometry = shape(data["geometry"])
+
+        # Iterate through each key-value pair in the flattened dictionary
         for key, value in flatdict.FlatDict(data).items():
             keys = key.split(":")
-            # print(keys)
-            # print(f"\t{value}")
-            # We already have the geometry
-            if key[:8] == "geometry":
+            # Skip the keys related to geometry
+            if key.startswith("geometry"):
                 continue
+            # If it's a top-level key, directly update self.config
             if len(keys) == 1:
-                self.config.update({key: value})
+                self.config[key] = value
                 continue
-            # keys[0] is currently always 'filters'
-            # keys[1] is currently 'tags' for the WHERE clause,
-            # of attributes for the SELECT
-            geom = keys[2]
-            # tag = keys[4]
-            # Get the geometry
-            if geom == "point":
-                geom = "nodes"
-            elif geom == "line":
-                geom = "ways_line"
-            elif geom == "polygon":
-                geom = "ways_poly"
-            if keys[1] == "attributes":
-                for v1 in value:
-                    if geom == "all_geometry":
-                        self.config["select"]["nodes"].append({v1: {}})
-                        self.config["select"]["ways_line"].append({v1: {}})
-                        self.config["select"]["ways_poly"].append({v1: {}})
-                        self.config["tables"].append("nodes")
-                        self.config["tables"].append("ways_poly")
-                        self.config["tables"].append("ways_line")
+
+            # Extract meaningful parts from the key
+            section, subsection = keys[:2]
+            geom_type = keys[2] if len(keys) > 2 else None
+            tag_type = keys[3] if len(keys) > 3 else None
+            tag_name = keys[4] if len(keys) > 4 else None
+
+            # Convert geometry type to meaningful names
+            geom_type = convert_geometry(geom_type)
+
+            if subsection == "attributes":
+                # For attributes, update select fields and tables
+                for attribute_name in value:
+                    if geom_type == "all_geometry":
+                        for geometry_type in ["nodes", "ways_line", "ways_poly"]:
+                            self.config["select"][geometry_type].append({attribute_name: {}})
+                            self.config["tables"].append(geometry_type)
                     else:
-                        self.config["tables"].append(geom)
-                        self.config["select"][geom].append({v1: {}})
-            if keys[1] == "tags":
-                newtag = {keys[4]: value}
-                newtag["op"] = keys[3][5:]
-                if geom == "all_geometry":
-                    self.config["where"]["nodes"].append(newtag)
-                    self.config["where"]["ways_poly"].append(newtag)
-                    self.config["where"]["ways_line"].append(newtag)
+                        self.config["select"][geom_type].append({attribute_name: {}})
+                        self.config["tables"].append(geom_type)
+            elif subsection == "tags":
+                # For tags, update where fields
+                option = tag_type[5:] if tag_type else None
+                new_tag = {tag_name: value, "op": option}
+                if geom_type == "all_geometry":
+                    for geometry_type in ["nodes", "ways_line", "ways_poly"]:
+                        self.config["where"][geometry_type].append(new_tag)
                 else:
-                    self.config["where"][geom].append(newtag)
+                    self.config["where"][geom_type].append(new_tag)
 
         return self.config
 

--- a/osm_rawdata/config.py
+++ b/osm_rawdata/config.py
@@ -185,7 +185,7 @@ class QueryConfig(object):
                     self.config["select"][table].append({tag: []})
 
     def parseJson(self, config: Union[str, BytesIO]):
-        """Parse the JSON format config file used by the raw-data-api and export tool.
+        """Parse the JSON format config file using the Underpass schema.
 
         Args:
             config (str, BytesIO): the file or BytesIO object to read.
@@ -193,6 +193,15 @@ class QueryConfig(object):
         Returns:
             config (dict): the config data
         """
+        # Check the type of config and load data accordingly
+        if isinstance(config, str):
+            with open(config, "r") as config_file:
+                data = json.load(config_file)
+        elif isinstance(config, BytesIO):
+            data = json.load(config)
+        else:
+            log.error(f"Unsupported config format: {config}")
+            raise ValueError(f"Invalid config {config}")
 
         # Helper function to convert geometry names
         def convert_geometry(geom):
@@ -203,16 +212,6 @@ class QueryConfig(object):
             elif geom == "polygon":
                 return "ways_poly"
             return geom
-
-        # Check the type of config and load data accordingly
-        if isinstance(config, str):
-            with open(config, "r") as config_file:
-                data = json.load(config_file)
-        elif isinstance(config, BytesIO):
-            data = json.load(config)
-        else:
-            log.error(f"Unsupported config format: {config}")
-            raise ValueError(f"Invalid config {config}")
 
         # Extract geometry
         self.geometry = shape(data["geometry"])

--- a/osm_rawdata/pgasync.py
+++ b/osm_rawdata/pgasync.py
@@ -20,6 +20,7 @@
 # <info@hotosm.org>
 
 import argparse
+import asyncio
 import json
 import logging
 import os
@@ -28,13 +29,11 @@ import time
 import zipfile
 from io import BytesIO
 from pathlib import Path
-from sys import argv
 from urllib.parse import urlparse
+
+import asyncpg
 import geojson
 import requests
-import asyncio
-import asyncpg
-from asyncpg import exceptions
 from geojson import Feature, FeatureCollection, Polygon
 from shapely import wkt
 from shapely.geometry import Polygon, shape
@@ -48,6 +47,7 @@ rootdir = rw.__path__[0]
 # Instantiate logger
 log = logging.getLogger(__name__)
 
+
 class DatabaseAccess(object):
     def __init__(self):
         """This is a class to setup a database connection."""
@@ -55,32 +55,33 @@ class DatabaseAccess(object):
         self.dburi = None
         self.qc = None
 
-    async def connect(self,
-            dburi: str,
-            ):
+    async def connect(
+        self,
+        dburi: str,
+    ):
         self.dburi = dict()
         uri = urlparse(dburi)
         if not uri.username:
-            self.dburi['dbuser'] = os.getenv("PGUSER", default=None)
-            if not self.dburi['dbuser']:
-                log.error(f"You must specify the user name in the database URI, or set PGUSER")
+            self.dburi["dbuser"] = os.getenv("PGUSER", default=None)
+            if not self.dburi["dbuser"]:
+                log.error("You must specify the user name in the database URI, or set PGUSER")
         else:
-            self.dburi['dbuser'] = uri.username
+            self.dburi["dbuser"] = uri.username
         if not uri.password:
-            self.dburi['dbpass'] = os.getenv("PGPASSWORD", default=None)
-            if not self.dburi['dbpass']:
-                log.error(f"You must specify the user password in the database URI, or set PGPASSWORD")
+            self.dburi["dbpass"] = os.getenv("PGPASSWORD", default=None)
+            if not self.dburi["dbpass"]:
+                log.error("You must specify the user password in the database URI, or set PGPASSWORD")
         else:
-            self.dburi['dbpass'] = uri.password
+            self.dburi["dbpass"] = uri.password
         if not uri.hostname:
-            self.dburi['dbhost'] = os.getenv("PGHOST", default="localhost")
+            self.dburi["dbhost"] = os.getenv("PGHOST", default="localhost")
         else:
-            self.dburi['dbhost'] = uri.hostname
+            self.dburi["dbhost"] = uri.hostname
 
-        slash = uri.path.find('/')
-        self.dburi['dbname'] = uri.path[slash + 1:]
+        slash = uri.path.find("/")
+        self.dburi["dbname"] = uri.path[slash + 1 :]
         connect = f"postgres://{self.dburi['dbuser']}:{ self.dburi['dbpass']}@{self.dburi['dbhost']}/{self.dburi['dbname']}"
-            
+
         if self.dburi["dbname"] == "underpass":
             # Authentication data
             # self.auth = HTTPBasicAuth(self.user, self.passwd)
@@ -292,11 +293,11 @@ class DatabaseAccess(object):
 
         return True
 
-    async def execute(self,
-                sql: str,
-                ):
-        """
-        Execute a raw SQL query and return the results.
+    async def execute(
+        self,
+        sql: str,
+    ):
+        """Execute a raw SQL query and return the results.
 
         Args:
             sql (str): The SQL to execute
@@ -441,17 +442,18 @@ class PostgresClient(DatabaseAccess):
         # output: str = None
     ):
         """This is a client for a postgres database.
+
         Returns:
             (PostgresClient): An instance of this class
         """
         super().__init__()
         self.qc = None
 
-    async def loadConfig(self,
-                config: str,
-                ):
-        """
-        Load the JSON or YAML config file that defines the SQL query
+    async def loadConfig(
+        self,
+        config: str,
+    ):
+        """Load the JSON or YAML config file that defines the SQL query
 
         Args:
             config (str): The filespec for the query config file
@@ -534,6 +536,7 @@ class PostgresClient(DatabaseAccess):
             collection = await self.queryRemote(request)
         return collection
 
+
 async def main():
     """This main function lets this class be run standalone by a bash script."""
     parser = argparse.ArgumentParser(
@@ -601,9 +604,9 @@ to define the are to be covered in the extract. Optionally a data file can be us
 
         log.debug(f"Wrote {args.outfile}")
 
+
 if __name__ == "__main__":
     """This is just a hook so this file can be run standalone during development."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     loop.run_until_complete(main())
-

--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -513,8 +513,11 @@ class DatabaseAccess(object):
         while elapsed_time < max_polling_duration:
             response = self.session.get(task_query_url, headers=self.headers)
             response_json = response.json()
+            response_status = response_json.get("status")
 
-            if response_json.get("status") == "PENDING":
+            log.debug(f"Current status: {response_status}")
+
+            if response_status == "PENDING":
                 # Adjust polling frequency after the first minute
                 if elapsed_time > 60:
                     polling_interval = 10  # Poll every 10 seconds after the first minute
@@ -524,7 +527,7 @@ class DatabaseAccess(object):
                 time.sleep(polling_interval)
                 elapsed_time += polling_interval
 
-            elif response_json.get("status") == "SUCCESS":
+            elif response_status == "SUCCESS":
                 break
 
         else:

--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -532,6 +532,10 @@ class DatabaseAccess(object):
             log.error(f"{max_polling_duration} second elapsed. Aborting data extract.")
             return None
 
+        if not isinstance(response_json, dict):
+            log.error(f"Raw data api response in wrong format: {response_json}")
+            return None
+
         data_url = response_json.get("result", {}).get("download_url")
         log.debug(f"Raw Data API Download URL: {data_url}")
 

--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -563,6 +563,7 @@ class PostgresClient(DatabaseAccess):
         self,
         uri: str,
         config: Optional[Union[str, BytesIO]] = None,
+        auth_token: Optional[str] = None,
         # output: str = None
     ):
         """This is a client for a postgres database.
@@ -577,6 +578,10 @@ class PostgresClient(DatabaseAccess):
         """
         super().__init__(uri)
         self.qc = QueryConfig()
+
+        # Optional authentication
+        if auth_token:
+            self.headers["access-token"] = auth_token
 
         if config:
             # filespec string passed

--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -536,8 +536,14 @@ class DatabaseAccess(object):
             log.error(f"Raw data api response in wrong format: {response_json}")
             return None
 
-        data_url = response_json.get("result", {}).get("download_url")
-        log.debug(f"Raw Data API Download URL: {data_url}")
+        info = response_json.get("result", {})
+        log.debug(f"Raw Data API Response: {info}")
+
+        data_url = info.get("download_url")
+
+        if not data_url:
+            log.error("Raw data api no download_url returned. Skipping.")
+            return None
 
         if not data_url.endswith(".zip"):
             return data_url

--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -517,7 +517,7 @@ class DatabaseAccess(object):
 
             log.debug(f"Current status: {response_status}")
 
-            if response_status == "PENDING":
+            if response_status == "STARTED" or response_status == "PENDING":
                 # Adjust polling frequency after the first minute
                 if elapsed_time > 60:
                     polling_interval = 10  # Poll every 10 seconds after the first minute

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022, 2023 Humanitarian OpenStreetMap Team
+#
+# This file is part of osm-rawdata.
+#
+#     osm-rawdata is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     osm-rawdata is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with osm-rawdata.  If not, see <https:#www.gnu.org/licenses/>.
+#
+"""Configuration and fixtures for PyTest."""
+
+import logging
+import sys
+
+import psycopg2
+import pytest
+
+logging.basicConfig(
+    level="DEBUG",
+    format=("%(asctime)s.%(msecs)03d [%(levelname)s] " "%(name)s | %(funcName)s:%(lineno)d | %(message)s"),
+    datefmt="%y-%m-%d %H:%M:%S",
+    stream=sys.stdout,
+)
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def db():
+    """Existing psycopg2 connection."""
+    return psycopg2.connect("postgresql://fmtm:testpass@db:5432/underpass")

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -69,6 +69,7 @@ def test_data_extract_flatgeobuf():
             "outputType": "fgb",
             "bind_zip": False,
         },
+        # param options: https://hotosm.github.io/raw-data-api/api/endpoints/#rawdatacurrentparams
     )
     assert extract_url.startswith("http")
 


### PR DESCRIPTION
Fixes:
- Handle data extract zip entirely in memory, without /tmp file.

Refactor:
- JSON config parsing in `config.QueryConfig.parseJson` and `postgres.PostgresClient.createJson` for clarity.

Feat:
- Allow passing extra params to `execQuery`, which are passed through to the JSON config for `queryRemote` (raw-data-api).
  - This allows for the `bind_zip` param to be passed. If it is, the URL to download is returned directly, instead of extracting from zip and returning the data.
- Added optional `clip_to_aoi` param to `execQuery`. This will remove polygons from the extract that have centroids falling outside the AOI.

Tests:
- Added three tests for generating different types of data extracts.