### PR TITLE
Add "AS geometry" to make parsing the results cleaner

### DIFF
--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -322,12 +322,14 @@ class DatabaseAccess(object):
         for table in config.config["tables"]:
             select = "SELECT "
             if allgeom:
-                select += "ST_AsText(geom)"
+                select += "ST_AsText(geom) AS geometry"
             else:
-                select += "ST_AsText(ST_Centroid(geom))"
+                select += "ST_AsText(ST_Centroid(geom)) AS geometry"
             select += ", osm_id, version, "
             for entry in config.config["select"][table]:
                 for k1, v1 in entry.items():
+                    if k1 == "osm_id" or k1 == "version":
+                        continue
                     select += f"tags->>'{k1}', "
             select = select[:-2]
 


### PR DESCRIPTION
When parsing the asyncpg.Records, rather than st_astext as a column, it now return geometry to be clearer. It also turned out that an extra tags->>'osm_id' and tags->>'version', was being added to the SELECT. These aren't tags, they're columns, and handled differently. This makes parsing the results of a query simpler.