### PR TITLE
Fix polling of raw-data-api on extract failure

### DIFF
--- a/osm_rawdata/postgres.py
+++ b/osm_rawdata/postgres.py
@@ -580,6 +580,10 @@ class DatabaseAccess(object):
 
             log.debug(f"Current status: {response_status}")
 
+            # First check to see if FAILURE and stop polling
+            if response_status == "FAILURE":
+                break
+
             # response_status options: STARTED, PENDING, SUCCESS
             if (
                 response_status != "SUCCESS"


### PR DESCRIPTION
We don't want behaviour like this:

![image](https://github.com/user-attachments/assets/c656f61b-92fa-4c53-bdba-2d083a8f6809)

Updated to prevent polling API if extract failure.