### PR TITLE
Fix for region path

### DIFF
--- a/osm_rawdata/geofabrik.py
+++ b/osm_rawdata/geofabrik.py
@@ -106,7 +106,8 @@ def main():
             )
             quit()
 
-        uri = f"http://download.geofabrik.de/{region.lower()}/{args.file.lower()}-latest.osm.pbf"
+        uri = f"http://download.geofabrik.de/{region.lower().replace(" ","-")}/{args.file.lower()}-latest.osm.pbf"
+        print(uri)
         outfile = f"./{args.file}-latest.osm.pbf"
         try:
             dl = SmartDL(uri, dest=outfile, connect_default_logger=False)


### PR DESCRIPTION
Replace space with an hyphen because `South America` was converted to `south america` instead of `south-america`