### PR TITLE
Fix importing into Postgres

### DIFF
--- a/osm_rawdata/importer.py
+++ b/osm_rawdata/importer.py
@@ -41,14 +41,14 @@ from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import create_database, database_exists
 
+import osm_rawdata as od
+
 # Find the other files for this project
-import osm_rawdata as rw
 import osm_rawdata.db_models
 from osm_rawdata.db_models import Base
 from osm_rawdata.overture import Overture
 from osm_rawdata.postgres import uriParser
 
-import osm_rawdata as od
 rootdir = od.__path__[0]
 
 #

--- a/osm_rawdata/importer.py
+++ b/osm_rawdata/importer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (c) 2022, 2023 Humanitarian OpenStreetMap Team
+# Copyright (c) 2022, 2023, 2024, 2025 Humanitarian OpenStreetMap Team
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -48,8 +48,10 @@ from osm_rawdata.db_models import Base
 from osm_rawdata.overture import Overture
 from osm_rawdata.postgres import uriParser
 
-rootdir = rw.__path__[0]
+import osm_rawdata as od
+rootdir = od.__path__[0]
 
+#
 # Instantiate logger
 log = logging.getLogger("osm-rawdata")
 
@@ -290,7 +292,7 @@ class MapImporter(object):
                 "--extra-attributes",
                 "--output=flex",
                 "--style",
-                f"{rootdir}/raw_with_ref.lua",
+                f"{rootdir}/import/raw.lua",
                 f"{infile}",
             ]
         )


### PR DESCRIPTION
Recent versions of osm2pgsql and LUA depreciated some functions, so the script for the custom SQL schema needed to be updated. In addition, the path to the script was fixed, as it's now in a sub-directory. Currently this has been broken on current Linux distributions for a while, I didn't notice as I was using this patch locally. Tested with several large PBFs from GeoFabrik. 